### PR TITLE
Trim bundle size by avoiding async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   "size-limit": [
     {
       "path": "dist/form.esm.js",
-      "limit": "5 KB"
+      "limit": "2 KB"
     },
     {
       "path": "dist/form.cjs.production.min.js",
-      "limit": "5 KB"
+      "limit": "2 KB"
     }
   ],
   "peerDependencies": {

--- a/src/useReset.ts
+++ b/src/useReset.ts
@@ -10,12 +10,13 @@ import { useEventCallback } from "./utilities/useEventCallback";
  * const reset = useReset(form);
  */
 export function useReset<Value, Result>(form: Form<Value, Result>): Reset {
-  return useEventCallback(async (event?: FormEvent<HTMLFormElement>) => {
+  return useEventCallback((event?: FormEvent<HTMLFormElement>) => {
     if (event) {
       event.preventDefault();
       event.stopPropagation();
     }
 
     form.reset();
+    return Promise.resolve();
   });
 }

--- a/src/utilities/toPromise.ts
+++ b/src/utilities/toPromise.ts
@@ -1,0 +1,11 @@
+/**
+ * If the value returned by the function is not a promise, convert it.
+ * Make sure to catch errors that are thrown syncronously.
+ */
+export function toPromise<T>(fn: () => T | PromiseLike<T>): Promise<T> {
+  try {
+    return Promise.resolve(fn());
+  } catch (error) {
+    return Promise.reject(error);
+  }
+}

--- a/test/utilities/toPromise.test.ts
+++ b/test/utilities/toPromise.test.ts
@@ -1,0 +1,32 @@
+import { toPromise } from "../../src/utilities/toPromise";
+
+describe("toPromise", () => {
+  test("converts sync success", async () => {
+    const promise = toPromise(() => 1);
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).resolves.toEqual(1);
+  });
+
+  test("converts sync error", async () => {
+    const promise = toPromise(() => {
+      throw new Error("boom");
+    });
+
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).rejects.toThrow(/boom/);
+  });
+
+  test("converts async success", async () => {
+    const promise = toPromise(() => Promise.resolve(1));
+
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).resolves.toEqual(1);
+  });
+
+  test("converts async error", async () => {
+    const promise = toPromise(() => Promise.reject(new Error("boom")));
+
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).rejects.toThrow(/boom/);
+  });
+});


### PR DESCRIPTION
Using async/await increases the bundle size by ~3kb. While that's a laughably small amount, it bothered me that more than half of the bundle size was dedicated to making async/await work.

We were really only using async/await in two places, so it wasn't a huge deal to convert.